### PR TITLE
Fix NPE on CalloutContract

### DIFF
--- a/org.eevolution.service-management/src/scala/org/eevolution/context/service/domain/callouts/CalloutContract.scala
+++ b/org.eevolution.service-management/src/scala/org/eevolution/context/service/domain/callouts/CalloutContract.scala
@@ -172,16 +172,18 @@ class CalloutContract extends CalloutEngine {
     import org.adempiere.core.domains.models.I_S_Contract
     val contract = GridTabWrapper.create(gridTab, classOf[I_S_Contract])
     val priceListId = contract.getM_PriceList_ID
-    if priceListId < 0 then return ""
+    if priceListId <= 0 then return ""
 
     val priceList = MPriceList.get(context, priceListId, null)
     val isTaxIncluded = priceList.isTaxIncluded
     val currencyId = priceList.getC_Currency_ID
     val contractDate = Env.getContextAsDate(context, windowNo, I_S_Contract.COLUMNNAME_DateContract)
-    val priceListVersion = priceList.getPriceListVersion(contractDate)
     contract.setIsTaxIncluded(isTaxIncluded)
     contract.setC_Currency_ID(currencyId)
-    Env.setContext(context, windowNo, "M_PriceList_Version_ID", priceListVersion.get_ID())
+    val priceListVersion =  priceList.getPriceListVersion(contractDate)
+    if priceListVersion != null then {
+    	Env.setContext(context, windowNo, "M_PriceList_Version_ID", priceListVersion.get_ID())
+    }
     ""
   }
 


### PR DESCRIPTION
## Summary
At create new contract, trigger an `null pointer exception` when do not selected an Price List or don't have an valid price list version for the contract. 

## Steps for review:

- Go to option /Service Management/Contract Lifecycle Management/Contract
- Create new Record

![image](https://github.com/adempiere/org.eevolution.service/assets/1847863/84f54bf7-dc25-4ed4-857e-99f05b317a0e)

![Screenshot_20240223_103658](https://github.com/adempiere/org.eevolution.service/assets/1847863/3f1b1bd9-8a6a-44eb-a41b-200f06128172)

## Error 

```
-----------> CConnection.isAppsServerOK: :3700
 - javax.naming.NoInitialContextException: Need to specify class name in environment or system property, or in an application resource file: java.naming.factory.initial
 - {} [1]
javax.naming.NoInitialContextException: Need to specify class name in environment or system property, or in an application resource file: java.naming.factory.initial
	at java.naming/javax.naming.spi.NamingManager.getInitialContext(NamingManager.java:702)
	at java.naming/javax.naming.InitialContext.getDefaultInitCtx(InitialContext.java:305)
	at java.naming/javax.naming.InitialContext.getURLOrDefaultInitCtx(InitialContext.java:342)
	at java.naming/javax.naming.InitialContext.lookup(InitialContext.java:409)
	at org.compiere.db.CConnection.lookup(CConnection.java:1787)
	at org.compiere.db.CConnection.isAppsServerOK(CConnection.java:398)
	at org.compiere.db.CConnectionEditor.setDisplay(CConnectionEditor.java:214)
	at org.compiere.db.CConnectionEditor.setValue(CConnectionEditor.java:182)
	at org.compiere.apps.ALogin.initLogin(ALogin.java:361)
	at org.compiere.apps.AMenu.initSystem(AMenu.java:245)
	at org.compiere.apps.AMenu.<init>(AMenu.java:113)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)
	at java.base/java.lang.Class.newInstance(Class.java:584)
	at org.adempiere.Adempiere.main(Adempiere.java:651)
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.erpya.lve.model.LVE [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.erpya.lve.model.LVE [20]
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.spin.conversion.model.validator.CurrencyConvertDocuments [20]
-----------> ModelValidationEngine.loadValidatorClass: client ANROS already exists for class: org.spin.conversion.model.validator.CurrencyConvertDocuments [20]
-----------> ModelValidationEngine.loadValidatorClass: client ANROS already exists for class: org.spin.wms.model.validator.ProductValidation [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.spin.model.validator.TravelAgencyManagement [20]
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.spin.cash.model.validator.CashManagement [20]
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.spin.consignment.model.validator.ConsignedMaterial [20]
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.spin.tpa.model.validator.ThirdPartyAccess [20]
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.spin.eos.model.validator.ConversionRate [20]
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.spin.eos.model.validator.ExchangeOperations [20]
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.spin.model.validator.FiscalPrinter [20]
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.spin.model.Withholding [20]
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.erpya.lve.model.FinancialBigTransactionTax [20]
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.erpya.lve.model.TaxDiscount [20]
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.spin.dms.model.validator.DeliveryManagementService [20]
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.spin.rmr.model.validator.RawMaterialManagement [20]
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.spin.pos.model.validator.ChangeTax [20]
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.spin.wms.model.validator.ExpressWMS [20]
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.spin.model.validator.TravelAgencyManagement [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.spin.cash.model.validator.CashManagement [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.spin.consignment.model.validator.ConsignedMaterial [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.spin.tpa.model.validator.ThirdPartyAccess [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.spin.eos.model.validator.ConversionRate [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.spin.eos.model.validator.ExchangeOperations [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.spin.model.validator.FiscalPrinter [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.spin.model.Withholding [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.erpya.lve.model.FinancialBigTransactionTax [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.erpya.lve.model.TaxDiscount [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.spin.dms.model.validator.DeliveryManagementService [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.spin.rmr.model.validator.RawMaterialManagement [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.spin.pos.model.validator.ChangeTax [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.spin.wms.model.validator.ExpressWMS [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.spin.wms.model.validator.ProductValidation [20]
-----------> ModelValidationEngine.loadValidatorClass: client INALCON already exists for class: org.spin.eca49.model.validator.OrderLine [20]
-----------> ModelValidationEngine.loadValidatorClass: client Industrias Maros C.A.  already exists for class: org.spin.eca49.model.validator.OrderLine [20]
-----------> DB.isBuildOK: Error en la versión de la construcción 

El programa asume version de construcción ADempiere, pero la base de datos tiene una versión ${ADEMPIERE_VERSION} 20200706-1035.
Es posible que esto cause errores difíciles de corregir.
Por favor contacte al ADMINISTRADOR. [1]
-----------> MPriceList.getPriceListVersion: None found M_PriceList_ID=0 - 2024-02-22 00:00:00.0 [20]
-----------> MIssue.set_Value: LoggerName - Value too long - truncated to length=60 [20]
===========> CalloutContract.start: start: priceList [20]
java.lang.NullPointerException
	at org.eevolution.context.service.domain.callouts.CalloutContract.priceList(CalloutContract.scala:184)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.compiere.model.CalloutEngine.start(CalloutEngine.java:109)
	at org.compiere.model.GridTab.processCallout(GridTab.java:2719)
	at org.compiere.model.GridTab.lambda$dataNew$1(GridTab.java:1175)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:658)
	at org.compiere.model.GridTab.dataNew(GridTab.java:1175)
	at org.compiere.apps.APanel.cmd_new(APanel.java:1945)
	at org.compiere.apps.APanel.actionPerformed(APanel.java:1750)
	at org.compiere.apps.AppsAction.actionPerformed(AppsAction.java:286)
	at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1967)
	at java.desktop/javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2308)
	at java.desktop/javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:405)
	at java.desktop/javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:262)
	at java.desktop/javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:279)
	at java.desktop/java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:297)
	at java.desktop/java.awt.Component.processMouseEvent(Component.java:6635)

===========> GridTab.processCallout: java.lang.NullPointerException [20]
-----------> MPriceList.getPriceListVersion: None found M_PriceList_ID=0 - 2024-02-22 00:00:00.0 [20]
-----------> MIssue.set_Value: LoggerName - Value too long - truncated to length=60 [20]
===========> CalloutContract.start: start: priceList [20]
java.lang.NullPointerException
	at org.eevolution.context.service.domain.callouts.CalloutContract.priceList(CalloutContract.scala:184)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.compiere.model.CalloutEngine.start(CalloutEngine.java:109)
	at org.compiere.model.GridTab.processCallout(GridTab.java:2719)
	at org.compiere.model.GridTab.lambda$dataNew$1(GridTab.java:1175)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:658)
	at org.compiere.model.GridTab.dataNew(GridTab.java:1175)
	at org.compiere.apps.APanel.cmd_new(APanel.java:1945)
	at org.compiere.apps.APanel.actionPerformed(APanel.java:1750)
	at org.compiere.apps.AppsAction.actionPerformed(AppsAction.java:286)
	at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1967)
	at java.desktop/javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2308)
	at java.desktop/javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:405)
	at java.desktop/javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:262)
	at java.desktop/javax.swing.plaf.basic.BasicButtonListener.mouseReleased(BasicButtonListener.java:279)
	at java.desktop/java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:297)
	at java.desktop/java.awt.Component.processMouseEvent(Component.java:6635)

===========> GridTab.processCallout: java.lang.NullPointerException [20]

```